### PR TITLE
Pass port number along from app config to Entity Manager config

### DIFF
--- a/src/DoctrineServiceProvider.php
+++ b/src/DoctrineServiceProvider.php
@@ -166,6 +166,7 @@ class DoctrineServiceProvider extends ServiceProvider
             'user'     => $config['username'],
             'password' => $config['password'],
             'charset'  => $config['charset'],
+            'port'     => $config['port'],
             'prefix'   => array_get($config, 'prefix'),
         ];
     }


### PR DESCRIPTION
Port was not being passed along in DB connection info, so using a non-standard port number would result in a failure of entity manager to connect to the DB.
