### PR TITLE
Depend on doctrine/orm ~2.5 instead of ~2.6@dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,9 +13,8 @@
             "email": "danijelmaricic@gmail.com"
         }
     ],
-    "minimum-stability": "dev",
     "require": {
-        "doctrine/orm": "~2.6@dev"
+        "doctrine/orm": "~2.5"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Fixes #4, closes #6.

Same as #6 but submitted to the develop branch instead of master.
