### PR TITLE
Only alias the EntityManager class if it doesn't yet exist.

### DIFF
--- a/src/DoctrineServiceProvider.php
+++ b/src/DoctrineServiceProvider.php
@@ -64,7 +64,9 @@ class DoctrineServiceProvider extends ServiceProvider
      */
     protected function registerFacades()
     {
-        class_alias('Nord\Lumen\Doctrine\ORM\Facades\EntityManager', 'EntityManager');
+        if (!class_exists('EntityManager')) {
+            class_alias('Nord\Lumen\Doctrine\ORM\Facades\EntityManager', 'EntityManager');
+        }
     }
 
 


### PR DESCRIPTION
See #17, when running unit tests, this file is included multiple times. The second time, the `EntityManager` class will already exist, so `class_alias` will fail with the following error:
```
Cannot declare class EntityManager, because the name is already in use
```

Wrapping the statement in a `class_exists` condition fixes this.

Fixes #17.